### PR TITLE
Spring REST Docs를 활용한 API 문서 자동화

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,4 @@
-:revision: 2022.02.0
+:revision: 2022.03.0
 :icons: font
 :main-title: Jeju-Road
 :sub-title: Back-end
@@ -54,7 +54,9 @@ $ cd {project_name}
 * link:{git_service}{project_name}/issues/5[도커 컨테이너 기반의 개발용 데이터베이스 환경 구축]
 * link:{git_service}{project_name}/issues/11[`MapStruct` 도입]
 * link:{git_service}{project_name}/issues/15[HTTP 응답 메시지의 페이로드에 대해 공통 포맷 적용]
-* link:{git_service}{project_name}/issues/16[@RestControllerAdvice를 활용한 예외처리 로직 구현]
+* link:{git_service}{project_name}/issues/16[`@RestControllerAdvice`를 활용한 예외처리 로직 구현]
+* link:{git_service}{project_name}/issues/21[`WebTestClient`를 활용한 웹 레이어 테스트 코드 구현]
+* link:{git_service}{project_name}/issues/13[`Spring REST Docs`를 활용한 API 문서 자동화]
 
 
 == License

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'org.springframework.boot' version '2.5.6'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+    id 'org.asciidoctor.jvm.convert' version '3.3.2'
     id 'java'
 }
 
@@ -12,6 +13,7 @@ configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
+    asciidoctorExt
 }
 
 repositories {
@@ -29,12 +31,34 @@ dependencies {
 
     runtimeOnly 'org.postgresql:postgresql'
 
+    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+
     implementation "org.mapstruct:mapstruct:1.4.2.Final"
     annotationProcessor "org.mapstruct:mapstruct-processor:1.4.2.Final"
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-webtestclient'
+}
+
+ext {
+    snippetsDir = file('build/generated-snippets')
 }
 
 test {
     useJUnitPlatform()
+}
+
+asciidoctor {
+    dependsOn test
+    configurations 'asciidoctorExt'
+    sourceDir 'src/main/asciidoc'
+    outputDir 'build/docs/'
+    attributes 'snippets': snippetsDir
+}
+
+bootJar {
+    dependsOn asciidoctor
+    from ("${asciidoctor.outputDir}/") {
+        into 'static/docs'
+    }
 }

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -1,0 +1,39 @@
+= 📄 REST API Reference
+Cheolho Jeon <woung2770@gmail.com>
+:toc: left
+
+== Introduction
+본 문서는 시스템에서 제공하는 전체 REST API에 대해 기술합니다. 각 API는 아래의 세부 목차로 구성되어 있습니다.
+
+[horizontal]
+HTTP Request*:: 요청 메시지 전체를 기술
+Path Parameter:: 요청 메시지의 경로 변수를 기술
+Request Fields:: 요청 메시지의 페이로드에 포함될 수 있는 JSON 프로퍼티를 기술
+HTTP Response*:: 응답 메시지 전체를 기술
+Response Fields*:: 응답 메시지의 페이로드에 포함될 수 있는 JSON 프로퍼티를 기술
+
+TIP: **'*'**는 필수적으로 포함되는 항목입니다.
+
+== Restaurant
+
+=== **[POST] /api/restaurants - 맛집 등록**
+****
+[discrete]
+==== Description
+시스템에 맛집 등록을 요청합니다.
+
+operation::restaurants/register[snippets='curl-request,http-request,request-fields,http-response,response-fields-information']
+****
+
+
+=== **[GET] /api/restaurants - 맛집 목록 조회**
+****
+[discrete]
+==== Description
+시스템에 등록된 맛집의 목록을 조회합니다.
+
+operation::restaurants/findAll[snippets='curl-request,http-request,http-response,response-fields-information']
+****
+
+
+

--- a/src/test/resources/org/springframework/restdocs/templates/asciidoctor/request-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/asciidoctor/request-fields.snippet
@@ -1,0 +1,11 @@
+|===
+|Path|Type|Optional|Description
+
+{{#fields}}
+|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+|{{#tableCellContent}}`+{{optional}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+
+{{/fields}}
+|===


### PR DESCRIPTION
애플리케이션 실행 후, 웹 브라우져에서 `/docs/index.html` 경로로 API 문서에 접근할 수 있습니다.

<img width="1712" alt="스크린샷 2022-01-17 오전 1 54 47" src="https://user-images.githubusercontent.com/42791260/149669961-78ccfc2c-2aee-4666-8cdc-8d4f6eab0fbb.png">
