### PR TITLE
#54 팁 목록조회 null값 전달 및 맛집 상세조회 시 메뉴정보 null 전달하는 오류 해결

### DIFF
--- a/src/main/java/com/jejuroad/domain/restaurant/Menu.java
+++ b/src/main/java/com/jejuroad/domain/restaurant/Menu.java
@@ -12,7 +12,7 @@ import static lombok.AccessLevel.PACKAGE;
 
 @Entity
 @EntityListeners(AuditingEntityListener.class)
-@Getter(PACKAGE)
+@Getter
 @NoArgsConstructor
 @RequiredArgsConstructor(access = PACKAGE)
 public class Menu {
@@ -39,13 +39,5 @@ public class Menu {
     @LastModifiedDate
     @Column(name = "update_datetime", nullable = false)
     private LocalDateTime updatedAt;
-
-    public Long getId() {
-        return id;
-    }
-
-    public String getName() {
-        return name;
-    }
 
 }

--- a/src/main/java/com/jejuroad/domain/restaurant/RestaurantMapper.java
+++ b/src/main/java/com/jejuroad/domain/restaurant/RestaurantMapper.java
@@ -24,8 +24,6 @@ public interface RestaurantMapper {
 
     RestaurantResponse.FindWithDetail.Menu map(Menu menu);
 
-    RestaurantResponse.FindTip mapToFindTipFrom(Tip tip);
-
     default List<String> map(List<Tip> tips) {
         return tips.stream().map(Tip::getContent).collect(Collectors.toList());
     }
@@ -44,6 +42,10 @@ public interface RestaurantMapper {
 
     default RestaurantResponse.FindCategory mapToFindCategoryFrom(Category category) {
         return new RestaurantResponse.FindCategory(category.getName());
+    }
+
+    default RestaurantResponse.FindTip mapToFindTipFrom(Tip tip) {
+        return new RestaurantResponse.FindTip(tip.getId(), tip.getContent());
     }
 
 }


### PR DESCRIPTION
 - #54 팁 목록조회 API 호출 시 발생하는 null 값 전달에 대한 오류 해결입니다.
 - 팁 목록 조회는 작성해놓은 mapper 인터페이스의 동작이 정상적으로 되지 않았던 것으로 default method로 직접 구현부를 작성했습니다.
 - 메뉴정보의 경우엔 Getter의 범위가 패키지로 제한되어 있는 것을 제거했습니다.